### PR TITLE
chore: upgrade `pnpm` version to 9.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier": "^3.1.0",
     "turbo": "latest"
   },
-  "packageManager": "pnpm@8.9.0",
+  "packageManager": "pnpm@9.0.4",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
PNPM v9 has multiple fixes for `postinstall` scripts for Apple M-processors in particular