### PR TITLE
Fix ERC20 ABI import case sensitivity issue

### DIFF
--- a/apps/berps-bot/src/tradingBot.ts
+++ b/apps/berps-bot/src/tradingBot.ts
@@ -5,7 +5,7 @@ import { PythConnection } from "./pyth";
 import { calculateBollingerBands } from "./bb";
 import { CONFIG } from "./config";
 import EntrypointABI from "./ABIs/entrypoint.json";
-import Erc20ABI from "./ABIs/ERC20.json";
+import Erc20ABI from "./ABIs/erc20.json";
 
 const HONEY = "0x0E4aaF1351de4c0264C5c7056Ef3777b41BD8e03";
 


### PR DESCRIPTION
Fixed TypeScript compilation error by correcting the case sensitivity in the ERC20 ABI import path. Changed import from "./ABIs/ERC20.json" to "./ABIs/erc20.json" to match the actual filename on disk.