### PR TITLE
fix: align reth discovery port with node port

### DIFF
--- a/apps/node-scripts/run-reth.sh
+++ b/apps/node-scripts/run-reth.sh
@@ -23,8 +23,8 @@ $RETH_BIN node 					\
 	--http					\
 	--http.addr 0.0.0.0			\
 	--http.port $EL_ETHRPC_PORT		\
-        --ipcpath /tmp/reth.ipc.$EL_ETHRPC_PORT \
-        --discovery.port $EL_ETHRPC_PORT	\
+	--ipcpath /tmp/reth.ipc.$EL_ETHRPC_PORT \
+	--discovery.port $EL_ETH_PORT	\
 	--http.corsdomain '*'			\
 	--log.file.directory $LOG_DIR		\
 	--engine.persistence-threshold 0	\


### PR DESCRIPTION
Previously, the --discovery.port parameter incorrectly used the EL_ETHRPC_PORT 
variable (HTTP-RPC port) rather than the node's network port (EL_ETH_PORT). 

This change:
- Sets --discovery.port to use $EL_ETH_PORT instead of $EL_ETHRPC_PORT
- Maintains parity with reth's default behavior where both --port (TCP) 
  and --discovery.port (UDP) default to 30303
- Preserves the ability to configure custom sequential ports via PORT_BASE

Reference: [node.md](https://github.com/paradigmxyz/reth/blob/eeaa65a6688c6fc96520fb701770ebe1b8689ec2/book/cli/reth/node.md?plain=1#L419).