### PR TITLE
Update beacond binary to env var

### DIFF
--- a/apps/node-scripts/setup-beacond.sh
+++ b/apps/node-scripts/setup-beacond.sh
@@ -57,5 +57,5 @@ sed $SED_OPT 's|^prometheus_listen_addr = ".*"|prometheus_listen_addr = "':$CL_P
 echo "✓ Config files in $BEACOND_CONFIG updated"
 
 echo -n "Genesis validator root: "
-beacond genesis validator-root $BEACOND_CONFIG/genesis.json 
+$BEACOND_BIN genesis validator-root $BEACOND_CONFIG/genesis.json 
 echo "✓ Beacon-Kit set up. Confirm genesis root is correct."

--- a/apps/node-scripts/setup-beacond.sh
+++ b/apps/node-scripts/setup-beacond.sh
@@ -38,20 +38,19 @@ echo "✓ JWT secret generated at $JWT_PATH"
 
 cp "$SEED_DATA_DIR/genesis.json" "$BEACOND_CONFIG/genesis.json"
 cp "$SEED_DATA_DIR/kzg-trusted-setup.json" "$BEACOND_CONFIG/kzg-trusted-setup.json"
-
-cp "$SEED_DATA_DIR/app.toml" "$BEACOND_CONFIG/app.toml"
-sed $SED_OPT 's|^moniker = ".*"|moniker = "'$MONIKER_NAME'"|' "$BEACOND_CONFIG/config.toml"
-
 cp "$SEED_DATA_DIR/config.toml" "$BEACOND_CONFIG/config.toml"
+cp "$SEED_DATA_DIR/app.toml" "$BEACOND_CONFIG/app.toml"
+
 sed $SED_OPT 's|^rpc-dial-url = ".*"|rpc-dial-url = "'http://localhost:$EL_AUTHRPC_PORT'"|' "$BEACOND_CONFIG/app.toml"
+sed $SED_OPT 's|^jwt-secret-path = ".*"|jwt-secret-path = "'$JWT_PATH'"|' "$BEACOND_CONFIG/app.toml"
+sed $SED_OPT 's|^trusted-setup-path = ".*"|trusted-setup-path = "'$BEACOND_CONFIG/kzg-trusted-setup.json'"|' "$BEACOND_CONFIG/app.toml"
+sed $SED_OPT 's|^suggested-fee-recipient = ".*"|suggested-fee-recipient = "'$WALLET_ADDRESS_FEE_RECIPIENT'"|' "$BEACOND_CONFIG/app.toml"
+
+sed $SED_OPT 's|^moniker = ".*"|moniker = "'$MONIKER_NAME'"|' "$BEACOND_CONFIG/config.toml"
 sed $SED_OPT 's|^laddr = ".*26657"|laddr = "tcp://127.0.0.1:'$CL_ETHRPC_PORT'"|' "$BEACOND_CONFIG/config.toml"
 sed $SED_OPT 's|^laddr = ".*26656"|laddr = "tcp://127.0.0.1:'$CL_ETHP2P_PORT'"|' "$BEACOND_CONFIG/config.toml"
 sed $SED_OPT 's|^external_address = ".*"|external_address = "'$MY_IP:$CL_ETHP2P_PORT'"|' "$BEACOND_CONFIG/config.toml"
 sed $SED_OPT 's|^proxy_app = ".*26658"|proxy_app = "tcp://127.0.0.1:'$CL_ETHPROXY_PORT'"|' "$BEACOND_CONFIG/config.toml"
-
-sed $SED_OPT 's|^jwt-secret-path = ".*"|jwt-secret-path = "'$JWT_PATH'"|' "$BEACOND_CONFIG/app.toml"
-sed $SED_OPT 's|^trusted-setup-path = ".*"|trusted-setup-path = "'$BEACOND_CONFIG/kzg-trusted-setup.json'"|' "$BEACOND_CONFIG/app.toml"
-sed $SED_OPT 's|^suggested-fee-recipient = ".*"|suggested-fee-recipient = "'$WALLET_ADDRESS_FEE_RECIPIENT'"|' "$BEACOND_CONFIG/app.toml"
 sed $SED_OPT 's|^prometheus_listen_addr = ".*"|prometheus_listen_addr = "':$CL_PROMETHEUS_PORT'"|' "$BEACOND_CONFIG/config.toml"
 
 echo "✓ Config files in $BEACOND_CONFIG updated"


### PR DESCRIPTION
While working with the setup scripts, two issues where identified.
1. The binary in setup-beacond wasn't referenced from the variable set in env
2. The sed command to replace the moniker was done before the file was copied.