### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled command line

### DIFF
--- a/exp/pol-performance-study/create_genesis_validators.js
+++ b/exp/pol-performance-study/create_genesis_validators.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const https = require('https');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const { parse } = require('csv-parse/sync');
 const { stringify } = require('csv-stringify/sync');
 
@@ -35,9 +35,16 @@ function getOperator(pubkey) {
     // Remove '0x' prefix if present and add it back to ensure consistent format
     const formattedPubkey = pubkey.startsWith('0x') ? pubkey : `0x${pubkey}`;
     
-    const command = `cast call ${BEACON_DEPOSIT_ADDRESS} "getOperator(bytes)" ${formattedPubkey} --rpc-url ${RPC_URL}`;
+    const args = [
+      'call',
+      BEACON_DEPOSIT_ADDRESS,
+      'getOperator(bytes)',
+      formattedPubkey,
+      '--rpc-url',
+      RPC_URL
+    ];
     
-    exec(command, (error, stdout, stderr) => {
+    execFile('cast', args, (error, stdout, stderr) => {
       if (error) {
         console.error(`Error executing cast command: ${error.message}`);
         console.error(`stderr: ${stderr}`);


### PR DESCRIPTION
Potential fix for [https://github.com/berachain/guides/security/code-scanning/4](https://github.com/berachain/guides/security/code-scanning/4)

To fix this issue, we should avoid directly interpolating potentially untrusted data (`pubkey`) into a shell command string for execution via `exec`. Instead, use `child_process.execFile` or `child_process.execFileSync` (or their async equivalents) which accept the command and arguments as an array, bypassing shell expansion and eliminating shell injection risks. In this scenario, we can refactor `getOperator` to use `execFile`, passing `formattedPubkey` (and any other args) as separate elements in the arguments array. No change to existing functionality is required, only a refactor from `exec` to `execFile`. The required import is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
