### PR TITLE
fix(erpc-proxy-caching): replace defunct Blast/Bartio with Bepolia RPC

### DIFF
--- a/apps/erpc-proxy-caching/README.md
+++ b/apps/erpc-proxy-caching/README.md
@@ -19,10 +19,9 @@ logLevel: debug
 projects:
   - id: main
     upstreams:
-      # You don't need to define architecture (e.g. evm) or chain id (e.g. 80084)
+      # You don't need to define architecture (e.g. evm) or chain id (e.g. 80069)
       # as they will be detected automatically by eRPC.
-      - endpoint: https://berachain-bartio.blastapi.io/xxxx
-      - endpoint: evm+alchemy://xxxx-my-alchemy-api-key-xxxx
+      - endpoint: https://bepolia.rpc.berachain.com
 ```
 
 See [a complete config example](https://docs.erpc.cloud/config/example) for inspiration.
@@ -36,12 +35,12 @@ docker run -v $(pwd)/erpc.yaml:/root/erpc.yaml -p 4000:4000 -p 4001:4001 ghcr.io
 3. Send your first request:
 
 ```bash
-curl --location 'http://localhost:4000/main/evm/80084' \
+curl --location 'http://localhost:4000/main/evm/80069' \
 --header 'Content-Type: application/json' \
 --data '{
     "method": "eth_getBlockByNumber",
     "params": [
-        "0x226c32",
+        "latest",
         false
     ],
     "id": 9199,
@@ -56,7 +55,7 @@ curl --location 'http://localhost:4000/main/evm/80084' \
 git clone https://github.com/erpc/erpc.git
 cd erpc
 
-# bring up the monitoring stack
+# bring up monitoring stack
 docker-compose up -d
 ```
 

--- a/apps/erpc-proxy-caching/erpc.yaml.dist
+++ b/apps/erpc-proxy-caching/erpc.yaml.dist
@@ -24,7 +24,7 @@ projects:
     networks:
       - architecture: evm
         evm:
-          chainId: 80084
+          chainId: 80069
         failsafe:
           timeout:
             duration: 8s
@@ -38,29 +38,13 @@ projects:
             delay: 3000ms
             maxCount: 2
     upstreams:
-      - id: chain-80084-https://bartio.rpc.berachain.com
+      - id: chain-80069-https://bepolia.rpc.berachain.com
         type: evm
-        endpoint: https://bartio.rpc.berachain.com
+        endpoint: https://bepolia.rpc.berachain.com
         rateLimitBucket: global
         healthCheckGroup: aggressive
         evm:
-          chainId: 80084
-        failsafe:
-          timeout:
-            duration: 5s
-          retry:
-            maxCount: 2
-            delay: 500ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 100ms
-      - id: chain-80084-https://bartio.drpc.org
-        type: evm
-        endpoint: https://bartio.drpc.org
-        rateLimitBucket: global
-        healthCheckGroup: aggressive
-        evm:
-          chainId: 80084
+          chainId: 80069
         failsafe:
           timeout:
             duration: 5s

--- a/apps/erpc-proxy-caching/erpc.yaml.dist
+++ b/apps/erpc-proxy-caching/erpc.yaml.dist
@@ -1,73 +1,81 @@
 logLevel: warn
 
-database:
-  evmJsonRpcCache:
-    driver: memory
-    maxItems: 10000
-    # driver: postgresql
-    # postgresql:
-    #   connectionUri: >-
-    #     postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@your.postgres.hostname.here.com:5432/your_database_name
-    #   table: rpc_cache
-
 server:
-  httpHost: 0.0.0.0
-  httpPort: 4000
+  httpHostV4: "0.0.0.0"
+  httpPortV4: 4000
 
 metrics:
   enabled: true
-  host: 0.0.0.0
+  hostV4: "0.0.0.0"
   port: 4001
+
+database:
+  evmJsonRpcCache:
+    connectors:
+      - id: memory-cache
+        driver: memory
+        memory:
+          maxItems: 10000
+      # - id: postgres-cache
+      #   driver: postgresql
+      #   postgresql:
+      #     connectionUri: >-
+      #       postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@your.postgres.hostname.here.com:5432/your_database_name
+      #     table: rpc_cache
+    policies:
+      - network: "*"
+        method: "*"
+        finality: finalized
+        connector: memory-cache
+        ttl: 0
+      - network: "*"
+        method: "*"
+        finality: unfinalized
+        connector: memory-cache
+        ttl: 5s
 
 projects:
   - id: main
+    rateLimitBudget: global
     networks:
       - architecture: evm
         evm:
           chainId: 80069
         failsafe:
-          timeout:
-            duration: 8s
-          retry:
-            maxCount: 5
-            delay: 500ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 200ms
-          hedge:
-            delay: 3000ms
-            maxCount: 2
+          - matchMethod: "*"
+            timeout:
+              duration: 8s
+            retry:
+              maxAttempts: 5
+              delay: 500ms
+              backoffMaxDelay: 10s
+              backoffFactor: 0.3
+              jitter: 200ms
+            hedge:
+              delay: 3000ms
+              maxCount: 2
     upstreams:
-      - id: chain-80069-https://bepolia.rpc.berachain.com
+      - id: bepolia-official
         type: evm
         endpoint: https://bepolia.rpc.berachain.com
-        rateLimitBucket: global
-        healthCheckGroup: aggressive
+        rateLimitBudget: global
         evm:
           chainId: 80069
         failsafe:
-          timeout:
-            duration: 5s
-          retry:
-            maxCount: 2
-            delay: 500ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 100ms
+          - matchMethod: "*"
+            timeout:
+              duration: 5s
+            retry:
+              maxAttempts: 2
+              delay: 500ms
+              backoffMaxDelay: 10s
+              backoffFactor: 0.3
+              jitter: 100ms
 
 rateLimiters:
-  buckets:
+  budgets:
     - id: global
       rules:
         - method: "*"
           maxCount: 1000
           period: 1s
-          scope: instance
-
-healthChecks:
-  groups:
-    - id: aggressive
-      checkInterval: 30s
-      maxErrorRatePercent: 10
-      maxP90LatencyMs: 5s
-      maxBlocksBehind: 5


### PR DESCRIPTION
## Summary
- Update `erpc.yaml.dist` to target Bepolia (chain ID 80069) via `https://bepolia.rpc.berachain.com` instead of defunct Bartio/Blast endpoints.
- Refresh README examples: Bepolia chain ID, public RPC URL, and a `latest` block query for local smoke tests.
- Remove redundant Bartio upstream entries so the sample config matches the current testnet.
- Modernize `erpc.yaml.dist` to the eRPC 0.0.64 config schema so the dist copy works with `ghcr.io/erpc/erpc:latest`.

## Test plan
- [x] Copy `erpc.yaml.dist` to `erpc.yaml` and run the documented `docker run` command.
- [x] Execute the README `curl` against `http://localhost:4000/main/evm/80069` and confirm a valid JSON-RPC response.
- [x] Skim README for any remaining Bartio (80084) or Blast API references.

Closes #135