### PR TITLE
feat(node-scripts): use CHAIN slug for Bera-Reth v1.4.1+

### DIFF
--- a/apps/node-scripts/README.md
+++ b/apps/node-scripts/README.md
@@ -2,9 +2,10 @@
 
 Full instructions are on [docs.berachain.com](https://docs.berachain.com/nodes/quickstart).
 
-1. Download or build beacon kit and bera-reth.
-   Ensure your $PATH includes where you installed it.
-2. Review and modify env.sh
+Requires Beacon Kit and Bera-Reth **v1.4.1** or later. Set `CHAIN` to `mainnet` or `bepolia` in `env.sh`.
+
+1. Install `beacond` and `bera-reth` and ensure both are on your `$PATH`.
+2. Review and modify `env.sh`.
 3. `./fetch-berachain-params.sh`
 4. In one window: `./setup-beacond.sh; ./run-beacond.sh`
 5. In another window: `./setup-reth.sh; ./run-reth.sh`

--- a/apps/node-scripts/env.sh
+++ b/apps/node-scripts/env.sh
@@ -2,7 +2,7 @@
 
 ########
 # CHANGE THESE VALUES
-export CHAIN_SPEC=mainnet   # "mainnet" or "testnet"
+export CHAIN=mainnet   # mainnet or bepolia
 export MONIKER_NAME=camembera
 export WALLET_ADDRESS_FEE_RECIPIENT=0x9BcaA41DC32627776b1A4D714Eef627E640b3EF5
 export EL_ARCHIVE_NODE=false # set to true if you want to run an archive node on CL and EL
@@ -45,18 +45,21 @@ fi
 ######
 # LEAVE BELOW ALONE. CAN CHANGE (most) DATA DIRECTORIES
 
-if [[ "$CHAIN_SPEC" == "testnet" ]]; then
-    export CHAIN=testnet-beacon-80069
-    export CHAIN_ID=80069
-else
-    export CHAIN=mainnet-beacon-80094
-    export CHAIN_ID=80094
-fi
+case "$CHAIN" in
+    mainnet)
+        export CHAIN_ID=80094
+        export BEACON_CHAIN_SPEC=mainnet
+        ;;
+    bepolia)
+        export CHAIN_ID=80069
+        export BEACON_CHAIN_SPEC=testnet
+        ;;
+    *)
+        echo "Error: CHAIN must be mainnet or bepolia (got: $CHAIN)"
+        exit 1
+        ;;
+esac
 export SEED_DATA_DIR=$(pwd)/seed-data-$CHAIN_ID
-
-if [ -f "$SEED_DATA_DIR/el-bootnodes.txt" ]; then
-    EL_BOOTNODES=$(grep '^enode://' "$SEED_DATA_DIR/el-bootnodes.txt"| tr '\n' ',' | sed 's/,$//')
-fi
 
 if [ -f "$SEED_DATA_DIR/el-peers.txt" ]; then
     EL_PEERS=$(grep '^enode://' "$SEED_DATA_DIR/el-peers.txt"| tr '\n' ',' | sed 's/,$//')
@@ -71,7 +74,6 @@ fi
 
 if command >/dev/null -v $RETH_BIN; then
     export RETH_DATA=$(pwd)/var/reth/data
-    export RETH_GENESIS_PATH=$(pwd)/var/reth/genesis.json
 fi  
 
 if ! command >/dev/null -v $RETH_BIN; then

--- a/apps/node-scripts/fetch-berachain-params.sh
+++ b/apps/node-scripts/fetch-berachain-params.sh
@@ -5,7 +5,7 @@ set -e
 
 mkdir -p "$SEED_DATA_DIR"
 
-export SEED_DATA_URL=https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.1/testing/networks/$CHAIN_ID
+export SEED_DATA_URL=https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/$CHAIN_ID
 curl -s -o "$SEED_DATA_DIR/kzg-trusted-setup.json" $SEED_DATA_URL/kzg-trusted-setup.json
 curl -s -o "$SEED_DATA_DIR/genesis.json" $SEED_DATA_URL/genesis.json
 curl -s -o "$SEED_DATA_DIR/el-peers.txt" $SEED_DATA_URL/el-peers.txt

--- a/apps/node-scripts/fetch-berachain-params.sh
+++ b/apps/node-scripts/fetch-berachain-params.sh
@@ -5,12 +5,10 @@ set -e
 
 mkdir -p "$SEED_DATA_DIR"
 
-export SEED_DATA_URL=https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/$CHAIN_ID
+export SEED_DATA_URL=https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.1/testing/networks/$CHAIN_ID
 curl -s -o "$SEED_DATA_DIR/kzg-trusted-setup.json" $SEED_DATA_URL/kzg-trusted-setup.json
 curl -s -o "$SEED_DATA_DIR/genesis.json" $SEED_DATA_URL/genesis.json
-curl -s -o "$SEED_DATA_DIR/eth-genesis.json" $SEED_DATA_URL/eth-genesis.json
 curl -s -o "$SEED_DATA_DIR/el-peers.txt" $SEED_DATA_URL/el-peers.txt
-curl -s -o "$SEED_DATA_DIR/el-bootnodes.txt" $SEED_DATA_URL/el-bootnodes.txt
 curl -s -o "$SEED_DATA_DIR/app.toml" $SEED_DATA_URL/app.toml
 curl -s -o "$SEED_DATA_DIR/config.toml" $SEED_DATA_URL/config.toml
 

--- a/apps/node-scripts/fetch-berachain-snapshot.js
+++ b/apps/node-scripts/fetch-berachain-snapshot.js
@@ -2,7 +2,7 @@
 
 /**
  * Berachain snapshot downloader. No env.sh required.
- * Index: mainnet uses snapshots.berachain.com; testnet uses bepolia.snapshots.berachain.com.
+ * Index: mainnet uses snapshots.berachain.com; bepolia uses bepolia.snapshots.berachain.com.
  * Large downloads use curl (-C) for resume; install curl on PATH.
  */
 
@@ -14,7 +14,7 @@ const DEFAULT_OUTPUT = 'downloads';
 
 function defaultIndexUrl(network) {
     const host =
-        network === 'testnet' ? 'bepolia.snapshots.berachain.com' : 'snapshots.berachain.com';
+        network === 'bepolia' ? 'bepolia.snapshots.berachain.com' : 'snapshots.berachain.com';
     return `https://${host}/index.csv`;
 }
 
@@ -40,13 +40,13 @@ function parseArgs() {
             case '--network':
             case '-n':
                 if (i + 1 >= args.length) {
-                    console.error('Error: --network requires a value (mainnet or testnet)');
+                    console.error('Error: --network requires a value (mainnet or bepolia)');
                     process.exit(1);
                 }
                 {
                     const val = args[++i];
-                    if (!['mainnet', 'testnet'].includes(val)) {
-                        console.error('Error: --network must be "mainnet" or "testnet"');
+                    if (!['mainnet', 'bepolia'].includes(val)) {
+                        console.error('Error: --network must be "mainnet" or "bepolia"');
                         process.exit(1);
                     }
                     config.network = val;
@@ -103,7 +103,7 @@ function parseArgs() {
 
 function showHelp() {
     const defMain = defaultIndexUrl('mainnet');
-    const defTest = defaultIndexUrl('testnet');
+    const defBepolia = defaultIndexUrl('bepolia');
     console.log(`
 Bera Snapshot Downloader
 
@@ -113,7 +113,7 @@ Requires Node.js 18+ for index fetch and curl on PATH for resumable downloads.
 Usage: node fetch-berachain-snapshot.js [options]
 
 Options:
-  -n, --network <network>     mainnet or testnet (default: mainnet)
+  -n, --network <network>     mainnet or bepolia (default: mainnet)
   -t, --type <type>           pruned or archive (default: pruned)
   -o, --output <dir>          download directory (default: downloads)
       --el-client <name>      execution row prefix in CSV (default: reth)
@@ -122,11 +122,11 @@ Options:
                               execution-layer snapshot only
   -h, --help                  show this help
 
-Index CSV: ${defMain} (mainnet), ${defTest} (testnet)
+Index CSV: ${defMain} (mainnet), ${defBepolia} (bepolia)
 
 Examples:
   node fetch-berachain-snapshot.js
-  node fetch-berachain-snapshot.js -n testnet -t archive -o /var/snapshots
+  node fetch-berachain-snapshot.js -n bepolia -t archive -o /var/snapshots
   node fetch-berachain-snapshot.js --execution-only -o ./downloads
 `);
 }

--- a/apps/node-scripts/run-reth.sh
+++ b/apps/node-scripts/run-reth.sh
@@ -4,15 +4,13 @@ set -e
 . ./env.sh
 
 PEERS_OPTION=${EL_PEERS:+--trusted-peers $EL_PEERS}
-BOOTNODES_OPTION=${EL_BOOTNODES:+--bootnodes $EL_BOOTNODES}
 ARCHIVE_OPTION=$([ "$EL_ARCHIVE_NODE" = true ] && echo "" || echo "--full")
 IP_OPTION=${MY_IP:+--nat extip:$MY_IP}
 
 $RETH_BIN node 					\
 	--datadir $RETH_DATA			\
-	--chain $RETH_GENESIS_PATH		\
+	--chain $CHAIN				\
 	$ARCHIVE_OPTION				\
-        $BOOTNODES_OPTION			\
 	$PEERS_OPTION				\
 	$IP_OPTION				\
 	--authrpc.addr 127.0.0.1		\

--- a/apps/node-scripts/setup-beacond.sh
+++ b/apps/node-scripts/setup-beacond.sh
@@ -21,7 +21,7 @@ echo "BEACOND_DATA: $BEACOND_DATA"
 echo "BEACOND_BIN: $BEACOND_BIN"
 echo "  Version: $($BEACOND_BIN version)"
 
-$BEACOND_BIN >/dev/null 2>&1 init $MONIKER_NAME --beacon-kit.chain-spec $CHAIN_SPEC --home $BEACOND_DATA 
+$BEACOND_BIN >/dev/null 2>&1 init $MONIKER_NAME --beacon-kit.chain-spec $BEACON_CHAIN_SPEC --home $BEACOND_DATA 
 CHECK_FILE=$BEACOND_CONFIG/priv_validator_key.json
 if [ ! -f "$CHECK_FILE" ]; then
     echo "Error: Private validator key was not created at $CHECK_FILE"

--- a/apps/node-scripts/setup-reth.sh
+++ b/apps/node-scripts/setup-reth.sh
@@ -12,10 +12,10 @@ fi
 
 echo "RETH_DATA: $RETH_DATA"
 echo "RETH_BIN: $RETH_BIN"
+echo "  Chain: $CHAIN"
 echo "  Version: $($RETH_BIN --version | grep Version)"
 
-cp "$SEED_DATA_DIR/eth-genesis.json" "$RETH_GENESIS_PATH"
-$RETH_BIN init --datadir "$RETH_DATA" --chain "$RETH_GENESIS_PATH" 
+$RETH_BIN init --datadir "$RETH_DATA" --chain "$CHAIN"
 
 echo
 echo "✓ Reth set up."


### PR DESCRIPTION
## Summary
- Operators set `CHAIN` to `mainnet` or `bepolia` in `env.sh`
- `run-reth.sh` and `setup-reth.sh` pass `--chain $CHAIN` (no genesis path, no bootnodes)
- `fetch-berachain-params.sh` downloads CL files only, pinned to beacon-kit v1.4.1
- `fetch-berachain-snapshot.js` accepts `--network mainnet|bepolia`

## Test plan
- [ ] `source env.sh` with `CHAIN=mainnet` and `CHAIN=bepolia`; invalid values exit 1
- [ ] `./fetch-berachain-params.sh` — seed dir has CL files only
- [ ] `./setup-reth.sh` with bera-reth v1.4.1+ on PATH
- [ ] `./run-reth.sh` invokes `bera-reth node --chain mainnet|bepolia` without `--bootnodes`